### PR TITLE
Force -coverage -O0 to be after the default -O2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ notifications:
     on_success: change
     on_failure: change
 
-# Freezes for whatever reason
 after_success:
+  # Workaround for covr not putting -O0 last
+  - mkdir -p ~/.R/ && echo "CFLAGS += -coverage -O0" > ~/.R/Makevars
   - Rscript -e 'covr::codecov(type = "all")'


### PR DESCRIPTION
The previous behavior was resulting in a compiler crash which was
causing travis to hang.

This fixes the issue on my local vagrant VM, hopefully will also fix it when run on travis.

https://github.com/jimhester/covr/issues/165 is opened to track this issue, I will have a fix in covr devel soon.
