### PR TITLE
Remove duplicated object file in Makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -7,7 +7,7 @@ LIBCMARK = cmark/cmark.o cmark/node.o cmark/iterator.o cmark/blocks.o cmark/inli
 	cmark/scanners.o cmark/utf8.o cmark/buffer.o cmark/references.o cmark/render.o \
 	cmark/man.o cmark/xml.o cmark/html.o cmark/commonmark.o cmark/latex.o cmark/houdini_href_e.o \
 	cmark/houdini_html_e.o cmark/houdini_html_u.o cmark/cmark_ctype.o cmark/arena.o \
-	cmark/html.o cmark/linked_list.o cmark/plugin.o cmark/registry.o cmark/syntax_extension.o \
+	cmark/linked_list.o cmark/plugin.o cmark/registry.o cmark/syntax_extension.o \
 	cmark/plaintext.o cmark/footnotes.o cmark/map.o \
 	extensions/autolink.o extensions/core-extensions.o extensions/ext_scanners.o \
 	extensions/strikethrough.o extensions/table.o extensions/tagfilter.o extensions/tasklist.o


### PR DESCRIPTION
The object file `cmark/html.o` appears twice in the `LIBCMARK` list in `src/Makevars`. This causes some linkers (`wasm-ld` in my case) to fail with a duplicated symbol error.