### PR TITLE
prevent single tildes from becoming strikethrough

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: commonmark
 Type: Package
 Title: High Performance CommonMark and Github Markdown Rendering in R
-Version: 1.9.1
+Version: 1.9.2
 Authors@R: c(
     person("Jeroen", "Ooms", ,"jeroen@berkeley.edu", role = c("aut", "cre"),
         comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+1.9.2
+  - Prevent single-tildes from being parsed as strikethrough (#25)
+
 1.9.1
   - Update libcmark-gfm to 0.29.0.gfm.13
 

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -71,6 +71,10 @@ SEXP R_render_markdown(SEXP text, SEXP format, SEXP sourcepos, SEXP hardbreaks, 
 
   /* Prevent filtering embedded resources: https://github.com/github/cmark-gfm#security */
   options += CMARK_OPT_UNSAFE;
+  /* Only process double tildes as strikethrough, otherwise, leave them asis 
+   * https://github.com/r-lib/commonmark/issues/25
+   * */
+  options += CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE;
 
   /* parse input */
   SEXP input = STRING_ELT(text, 0);

--- a/tests/testthat/test-extensions.R
+++ b/tests/testthat/test-extensions.R
@@ -5,14 +5,14 @@ test_that("list extensions", {
 })
 
 test_that("strikethrough", {
-  md <- "foo ~bar~ baz"
-  expect_equal(markdown_html(md, extensions = FALSE), "<p>foo ~bar~ baz</p>\n")
+  md <- "foo ~~bar~~ baz"
+  expect_equal(markdown_html(md, extensions = FALSE), "<p>foo ~~bar~~ baz</p>\n")
   expect_equal(markdown_html(md, extensions = TRUE), "<p>foo <del>bar</del> baz</p>\n")
 
-  expect_equal(markdown_latex(md, extensions = FALSE), "foo \\textasciitilde{}bar\\textasciitilde{} baz\n")
+  expect_equal(markdown_latex(md, extensions = FALSE), "foo \\textasciitilde{}\\textasciitilde{}bar\\textasciitilde{}\\textasciitilde{} baz\n")
   expect_equal(markdown_latex(md, extensions = TRUE), "foo \\sout{bar} baz\n")
 
-  expect_equal(markdown_man(md, extensions = FALSE), ".PP\nfoo ~bar~ baz\n")
+  expect_equal(markdown_man(md, extensions = FALSE), ".PP\nfoo ~~bar~~ baz\n")
   expect_equal(markdown_man(md, extensions = TRUE), ".PP\nfoo \n.ST \"bar\"\n baz\n")
 
   library(xml2)


### PR DESCRIPTION
This will fix #25.