### PR TITLE
Implement LaTeX footnotes using `\footnotemark` and `\footnotetext`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: commonmark
 Type: Package
 Title: High Performance CommonMark and Github Markdown Rendering in R
-Version: 1.9.3
+Version: 1.9.4
 Authors@R: c(
     person("Jeroen", "Ooms", ,"jeroenooms@gmail.com", role = c("aut", "cre"),
         comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
-1.9.3
+1.9.4
   - Apply upstream PR https://github.com/github/cmark-gfm/pull/362
+  - Implement LaTeX footnotes (#32)
 
 1.9.1
   - Update libcmark-gfm to 0.29.0.gfm.13

--- a/src/cmark/latex.c
+++ b/src/cmark/latex.c
@@ -447,8 +447,20 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
     break;
 
   case CMARK_NODE_FOOTNOTE_DEFINITION:
+    if (entering) {
+      LIT("\\footnotetext[");
+      OUT(cmark_chunk_to_cstr(renderer->mem, &node->as.literal), false, LITERAL);
+      LIT("]{");
+    } else {
+      LIT("}");
+    }
+    break;
   case CMARK_NODE_FOOTNOTE_REFERENCE:
-    // TODO
+    if (entering) {
+      LIT("\\footnotemark[");
+      OUT(cmark_chunk_to_cstr(renderer->mem, &node->parent_footnote_def->as.literal), false, LITERAL);
+      LIT("]");
+    }
     break;
 
   default:

--- a/src/patches/apply.sh
+++ b/src/patches/apply.sh
@@ -2,4 +2,5 @@
 
 # Upstream PR: https://github.com/github/cmark-gfm/pull/362
 patch -p2 -d ../cmark < 362.diff
-
+# Support footnotes for LaTeX: https://github.com/r-lib/commonmark/pull/32
+patch -p2 -d ../cmark < latex-footnotes.diff

--- a/src/patches/latex-footnotes.diff
+++ b/src/patches/latex-footnotes.diff
@@ -1,0 +1,26 @@
+diff --git a/src/cmark/latex.c b/src/cmark/latex.c
+index 1a6367a..5fab7ee 100644
+--- a/src/cmark/latex.c
++++ b/src/cmark/latex.c
+@@ -447,8 +447,20 @@ static int S_render_node(cmark_renderer *renderer, cmark_node *node,
+     break;
+ 
+   case CMARK_NODE_FOOTNOTE_DEFINITION:
++    if (entering) {
++      LIT("\\footnotetext[");
++      OUT(cmark_chunk_to_cstr(renderer->mem, &node->as.literal), false, LITERAL);
++      LIT("]{");
++    } else {
++      LIT("}");
++    }
++    break;
+   case CMARK_NODE_FOOTNOTE_REFERENCE:
+-    // TODO
++    if (entering) {
++      LIT("\\footnotemark[");
++      OUT(cmark_chunk_to_cstr(renderer->mem, &node->parent_footnote_def->as.literal), false, LITERAL);
++      LIT("]");
++    }
+     break;
+ 
+   default:

--- a/tests/testthat/test-extensions.R
+++ b/tests/testthat/test-extensions.R
@@ -42,6 +42,18 @@ test_that("autolink", {
 
 })
 
+test_that("footnotes", {
+  # a single footnote
+  md <- "Hello[^1]\n\n[^1]: A footnote."
+  expect_equal(markdown_latex(md, footnotes = FALSE), "Hello{[}\\^{}1{]}\n\n{[}\\^{}1{]}: A footnote.\n")
+  expect_equal(markdown_latex(md, footnotes = TRUE), "Hello\\footnotemark[1]\n\n\\footnotetext[1]{A footnote.\n\n}\n")
+
+  # multiple footnotes
+  md <- "Hello[^1] World[^foo-2]\n\n[^1]: A footnote.\n\n[^foo-2]: Footnote ID does not have to be a number."
+  expect_equal(markdown_latex(md, footnotes = FALSE), "Hello{[}\\^{}1{]} World{[}\\^{}foo-2{]}\n\n{[}\\^{}1{]}: A footnote.\n\n{[}\\^{}foo-2{]}: Footnote ID does not have to be a number.\n")
+  expect_equal(markdown_latex(md, footnotes = TRUE), "Hello\\footnotemark[1] World\\footnotemark[foo-2]\n\n\\footnotetext[1]{A footnote.\n\n}\\footnotetext[foo-2]{Footnote ID does not have to be a number.\n\n}\n")
+})
+
 test_that("embedded images do not get filtered", {
   md <- '<img src="data:image/png;base64,foobar" />\n'
   expect_equal(md, markdown_html(md))


### PR DESCRIPTION
This is the best I could achieve with my poor knowledge of C. Ideally, we should render footnotes into `\footnote{}` in the case of `CMARK_NODE_FOOTNOTE_REFERENCE`, but I can't figure out how I can get the footnote content from the node there (maybe that's just not possible). I'd very much appreciate help here.

Fixes https://github.com/github/cmark-gfm/issues/314