### PR TITLE
Require double-tilde for strikethrough

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Suggests:
     curl,
     testthat,
     xml2
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 Language: en-US
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
-1.9.3
+1.9.4
   - Apply upstream PR https://github.com/github/cmark-gfm/pull/362
+  - Require double-tilde `~~` for the strikethrough extension, for consistency with Pandoc's Markdown
 
 1.9.1
   - Update libcmark-gfm to 0.29.0.gfm.13

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -6,7 +6,7 @@
 #' Currently the following extensions are supported:
 #'
 #'  - **table** support rendering of tables: [gfm-spec section 4.10](https://github.github.com/gfm/#tables-extension-)
-#'  - **strikethrough** via `~sometext~` syntax: [gfm-spec section 6.5](https://github.github.com/gfm/#strikethrough-extension-)
+#'  - **strikethrough** via `~~sometext~~` syntax: [gfm-spec section 6.5](https://github.github.com/gfm/#strikethrough-extension-)
 #'  - **autolink** automatically turn URLs into hyperlinks: [gfm-spec section 6.9](https://github.github.com/gfm/#autolinks-extension-)
 #'  - **tagfilter** blacklist html tags: `title` `textarea` `style` `xmp` `iframe`
 #' `noembed` `noframes` `script` `plaintext`: [gfm-spec section 6.11](https://github.github.com/gfm/#disallowed-raw-html-extension-)

--- a/man/extensions.Rd
+++ b/man/extensions.Rd
@@ -15,7 +15,7 @@ features which are not (yet) in the official commonmark spec.
 Currently the following extensions are supported:
 \itemize{
 \item \strong{table} support rendering of tables: \href{https://github.github.com/gfm/#tables-extension-}{gfm-spec section 4.10}
-\item \strong{strikethrough} via \verb{~sometext~} syntax: \href{https://github.github.com/gfm/#strikethrough-extension-}{gfm-spec section 6.5}
+\item \strong{strikethrough} via \verb{~~sometext~~} syntax: \href{https://github.github.com/gfm/#strikethrough-extension-}{gfm-spec section 6.5}
 \item \strong{autolink} automatically turn URLs into hyperlinks: \href{https://github.github.com/gfm/#autolinks-extension-}{gfm-spec section 6.9}
 \item \strong{tagfilter} blacklist html tags: \code{title} \code{textarea} \code{style} \code{xmp} \code{iframe}
 \code{noembed} \code{noframes} \code{script} \code{plaintext}: \href{https://github.github.com/gfm/#disallowed-raw-html-extension-}{gfm-spec section 6.11}

--- a/src/wrapper.c
+++ b/src/wrapper.c
@@ -63,6 +63,7 @@ SEXP R_render_markdown(SEXP text, SEXP format, SEXP sourcepos, SEXP hardbreaks, 
 
   /* combine options */
   int options = CMARK_OPT_DEFAULT;
+  options += CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE;
   options += Rf_asLogical(sourcepos) * CMARK_OPT_SOURCEPOS;
   options += Rf_asLogical(hardbreaks) * CMARK_OPT_HARDBREAKS;
   options += Rf_asLogical(smart) * CMARK_OPT_SMART;

--- a/tests/testthat/test-extensions.R
+++ b/tests/testthat/test-extensions.R
@@ -5,19 +5,19 @@ test_that("list extensions", {
 })
 
 test_that("strikethrough", {
-  md <- "foo ~bar~ baz"
-  expect_equal(markdown_html(md, extensions = FALSE), "<p>foo ~bar~ baz</p>\n")
-  expect_equal(markdown_html(md, extensions = TRUE), "<p>foo <del>bar</del> baz</p>\n")
+  md <- "~Hello~ ~~world~~!"
+  expect_equal(markdown_html(md), "<p>~Hello~ ~~world~~!</p>\n")
+  expect_equal(markdown_html(md, extensions = "strikethrough"), "<p>~Hello~ <del>world</del>!</p>\n")
 
-  expect_equal(markdown_latex(md, extensions = FALSE), "foo \\textasciitilde{}bar\\textasciitilde{} baz\n")
-  expect_equal(markdown_latex(md, extensions = TRUE), "foo \\sout{bar} baz\n")
+  expect_equal(markdown_latex(md), "\\textasciitilde{}Hello\\textasciitilde{} \\textasciitilde{}\\textasciitilde{}world\\textasciitilde{}\\textasciitilde{}!\n")
+  expect_equal(markdown_latex(md, extensions = "strikethrough"), "\\textasciitilde{}Hello\\textasciitilde{} \\sout{world}!\n")
 
-  expect_equal(markdown_man(md, extensions = FALSE), ".PP\nfoo ~bar~ baz\n")
-  expect_equal(markdown_man(md, extensions = TRUE), ".PP\nfoo \n.ST \"bar\"\n baz\n")
+  expect_equal(markdown_man(md), ".PP\n~Hello~ ~~world~~!\n")
+  expect_equal(markdown_man(md, extensions = "strikethrough"), ".PP\n~Hello~ \n.ST \"world\"\n!\n")
 
   library(xml2)
-  doc1 <- xml_ns_strip(read_xml(markdown_xml(md, extensions = FALSE)))
-  doc2 <- xml_ns_strip(read_xml(markdown_xml(md, extensions = TRUE)))
+  doc1 <- xml_ns_strip(read_xml(markdown_xml(md)))
+  doc2 <- xml_ns_strip(read_xml(markdown_xml(md, extensions = "strikethrough")))
   expect_length(xml_find_all(doc1, "//strikethrough"), 0)
   expect_length(xml_find_all(doc2, "//strikethrough"), 1)
 


### PR DESCRIPTION
In Pandoc's Markdown, single tilde is for subscripts, e.g., `H~2~O`. GFM allows for both `~` and `~~` for strikethroughs, which I think is a really bad idea (cf jgm's first pain: https://johnmacfarlane.net/beyond-markdown.html).