### PR TITLE
add subscript extension

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 1.9.4
   - Apply upstream PR https://github.com/github/cmark-gfm/pull/362
   - Require double-tilde `~~` for the strikethrough extension, for consistency with Pandoc's Markdown
+  - Implement subscript extension for single tilde `~`
 
 1.9.1
   - Update libcmark-gfm to 0.29.0.gfm.13

--- a/src/Makevars
+++ b/src/Makevars
@@ -10,7 +10,7 @@ LIBCMARK = cmark/cmark.o cmark/node.o cmark/iterator.o cmark/blocks.o cmark/inli
 	cmark/linked_list.o cmark/plugin.o cmark/registry.o cmark/syntax_extension.o \
 	cmark/plaintext.o cmark/footnotes.o cmark/map.o \
 	extensions/autolink.o extensions/core-extensions.o extensions/ext_scanners.o \
-	extensions/strikethrough.o extensions/table.o extensions/tagfilter.o extensions/tasklist.o
+	extensions/subscript.o extensions/strikethrough.o extensions/table.o extensions/tagfilter.o extensions/tasklist.o
 
 PKG_LIBS = -Lcmark -lstatcmark
 STATLIB = cmark/libstatcmark.a

--- a/src/extensions/core-extensions.c
+++ b/src/extensions/core-extensions.c
@@ -1,5 +1,6 @@
 #include "cmark-gfm-core-extensions.h"
 #include "autolink.h"
+#include "subscript.h"
 #include "strikethrough.h"
 #include "table.h"
 #include "tagfilter.h"
@@ -9,6 +10,7 @@
 
 static int core_extensions_registration(cmark_plugin *plugin) {
   cmark_plugin_register_syntax_extension(plugin, create_table_extension());
+  cmark_plugin_register_syntax_extension(plugin, create_subscript_extension());
   cmark_plugin_register_syntax_extension(plugin,
                                          create_strikethrough_extension());
   cmark_plugin_register_syntax_extension(plugin, create_autolink_extension());

--- a/src/extensions/subscript.h
+++ b/src/extensions/subscript.h
@@ -1,0 +1,9 @@
+#ifndef CMARK_GFM_SUBSCRIPT_H
+#define CMARK_GFM_SUBSCRIPT_H
+
+#include "cmark-gfm-core-extensions.h"
+
+extern cmark_node_type CMARK_NODE_SUBSCRIPT;
+cmark_syntax_extension *create_subscript_extension(void);
+
+#endif

--- a/src/extensions/table.c
+++ b/src/extensions/table.c
@@ -8,6 +8,7 @@
 
 #include "ext_scanners.h"
 #include "strikethrough.h"
+#include "subscript.h"
 #include "table.h"
 #include "cmark-gfm-core-extensions.h"
 
@@ -548,6 +549,7 @@ static int can_contain(cmark_syntax_extension *extension, cmark_node *node,
            child_type == CMARK_NODE_EMPH || child_type == CMARK_NODE_STRONG ||
            child_type == CMARK_NODE_LINK || child_type == CMARK_NODE_IMAGE ||
            child_type == CMARK_NODE_STRIKETHROUGH ||
+           child_type == CMARK_NODE_SUBSCRIPT ||
            child_type == CMARK_NODE_HTML_INLINE ||
            child_type == CMARK_NODE_FOOTNOTE_REFERENCE;
   }

--- a/tests/testthat/test-extensions.R
+++ b/tests/testthat/test-extensions.R
@@ -1,7 +1,7 @@
 context("test-extensions")
 
 test_that("list extensions", {
-  expect_equal(list_extensions(), c("table", "strikethrough", "autolink", "tagfilter", "tasklist"))
+  expect_setequal(list_extensions(), c("table", "strikethrough", "subscript", "autolink", "tagfilter", "tasklist"))
 })
 
 test_that("strikethrough", {
@@ -22,6 +22,26 @@ test_that("strikethrough", {
   expect_length(xml_find_all(doc2, "//strikethrough"), 1)
 
 })
+
+test_that("subscript", {
+  md <- "H~2~O"
+  expect_equal(markdown_html(md), "<p>H~2~O</p>\n")
+  expect_equal(markdown_html(md, extensions = "subscript"), "<p>H<sub>2</sub>O</p>\n")
+
+  expect_equal(markdown_latex(md), "H\\textasciitilde{}2\\textasciitilde{}O\n")
+  expect_equal(markdown_latex(md, extensions = "subscript"), "H\\textsubscript{2}O\n")
+
+  expect_equal(markdown_man(md), ".PP\nH~2~O\n")
+  expect_equal(markdown_man(md, extensions = "subscript"), ".PP\nH\n\\d\\s-22\\s+2\\u\nO\n")
+
+  library(xml2)
+  doc1 <- xml_ns_strip(read_xml(markdown_xml(md)))
+  doc2 <- xml_ns_strip(read_xml(markdown_xml(md, extensions = "subscript")))
+  expect_length(xml_find_all(doc1, "//subscript"), 0)
+  expect_length(xml_find_all(doc2, "//subscript"), 1)
+
+})
+
 
 test_that("autolink", {
   md <- "Visit: https://www.test.com"


### PR DESCRIPTION
This implements a subscript extension for the single tilde. I would like help working this into a more robust patch format. 

I also note that this has the problem where both subscript and strikethrough use `~` as matching, so when they are both enabled, then the subscript markup is ignored and I'm not sure how to handle that. 

``` r
commonmark::markdown_commonmark("H~~2~~O and H~2~O", extensions = c("strikethrough", 
    "subscript"))
#> [1] "H~~2~~O and H\\~2\\~O\n"
```

<sup>Created on 2024-10-17 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>